### PR TITLE
Update realms-of-terrinoth.json > king of all golbins

### DIFF
--- a/api/index.json
+++ b/api/index.json
@@ -54,7 +54,7 @@
       "abbreviation": "RoT",
       "color": "#A75A0E",
       "url": "https://www.fantasyflightgames.com/en/products/genesys/products/realms-terrinoth/",
-      "version": "2024.12.26",
+      "version": "2025.1.14",
       "authors": [
          "Fantasy Flight Games"
       ],

--- a/api/realms-of-terrinoth.json
+++ b/api/realms-of-terrinoth.json
@@ -7,7 +7,7 @@
          "abbreviation": "RoT",
          "color": "#A75A0E",
          "url": "https://www.fantasyflightgames.com/en/products/genesys/products/realms-terrinoth/",
-         "version": "2024.12.26",
+         "version": "2025.1.14",
          "authors": [
             "Fantasy Flight Games"
          ],
@@ -7243,7 +7243,7 @@
          ]
       },
       {
-         "name": "Splig, King Of All Golbins",
+         "name": "Splig, King Of All Goblins",
          "type": "nemesis",
          "page": 154,
          "description": [


### PR DESCRIPTION
`Sprig, King of all Goblins` has a typo in the source book (RoT). This is being corrected here as the intention of the publication was for his name to spelled correctly